### PR TITLE
Added environment name to env.yml

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -1,3 +1,4 @@
+name: re3-test
 channels:
   - pytorch
   - anaconda


### PR DESCRIPTION
environment.yml files should specify the name of the environment in the first line, as shown here:
https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#create-env-file-manually

Without this the standard command
```
conda create -f env.yml
```
does not work.

The current file does work using the following command to specify an environment name:
```
conda create -f env.yml --name re3-test
```